### PR TITLE
Change target of zenodo workflow to data-repository

### DIFF
--- a/.github/workflows/zenodo_stats.yml
+++ b/.github/workflows/zenodo_stats.yml
@@ -18,10 +18,10 @@ jobs:
     - name: Check out repo
       uses: actions/checkout@v4 
       
-    - name: Check out NMRLipids/Databank
+    - name: Check out NMRLipids/BilayerData
       uses: actions/checkout@v4
       with:
-        repository: NMRLipids/Databank
+        repository: NMRLipids/BilayerData
         path: NMRLipidsDB
     
     # Get zenodo DOIs and query stats from API
@@ -31,7 +31,7 @@ jobs:
    
     # Commits files to repository
     - name: Commit changes
-      uses: EndBug/add-and-commit@v4
+      uses: EndBug/add-and-commit@v9
       with:
         author_name: GitHub action
         message: "Zenodo stats"


### PR DESCRIPTION
This PR just points the zenodo workflow to the BilayerData repository in preparation for the data separation. The merge here can happen right after the data separation if we want the stats to be completely up to date.  